### PR TITLE
Build fix for ubuntu - but might help many others.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ CPPFLAGS += ${shell $(FTC) --cflags}
 CPPFLAGS += ${patsubst %,-I%,${subst :, ,${IPATH}}}
 
 LDFLAGS = ${shell pkg-config --libs IL 2>/dev/null}
-LDFLAGS += -lpthread -lutil -ldl
-LDFLAGS += -lm
 LDFLAGS += -Wl,-rpath $(LIBC3)/${OBJ}/.libs -L$(LIBC3)/${OBJ}/.libs -lc3 -lc3gl
 LDFLAGS += -Wl,-rpath ${SIMAVR_R}/simavr/${OBJ} -L${SIMAVR_R}/simavr/${OBJ} 
 LDFLAGS += -L${FTGL}/${OBJ} -lfreetype-gl ${shell $(FTC) --libs} 
+LDFLAGS += -lpthread -lutil -ldl
+LDFLAGS += -lm
 
 include ${SIMAVR_R}/examples/Makefile.opengl
 


### PR DESCRIPTION
Main system libs should be listed last on the ld command line, as ordering matters there and they are potentially needed by higher level libs.